### PR TITLE
Added sc_setDenormalFlags() for systems with vfp

### DIFF
--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -181,6 +181,29 @@ void sc_SetDenormalFlags()
 	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 }
 
+#elif defined(__VFP_FP__)
+// vfp is the IEE-754-compliant fp unit on
+// the Cortex A8, along with the SIMD Neon unit
+// these function turns on "fast mode" by enabling
+// flushing denormals to zero on the VFP.
+void sc_SetDenormalFlags(){
+/* This code is from math-neon/math_runfast.c
+Copyright (c) 2015 Lachlan Tychsen-Smith (lachlan.ts@gmail.com)
+MIT License (MIT)
+ */
+	static const unsigned int x = 0x04086060;
+	static const unsigned int y = 0x03000000;
+	int r;
+	asm volatile (
+		"fmrx	%0, fpscr			\n\t"	//r0 = FPSCR
+		"and	%0, %0, %1			\n\t"	//r0 = r0 & 0x04086060
+		"orr	%0, %0, %2			\n\t"	//r0 = r0 | 0x03000000
+		"fmxr	fpscr, %0			\n\t"	//FPSCR = r0
+		: "=r"(r)
+		: "r"(x), "r"(y)
+	);
+}
+
 #else
 
 void sc_SetDenormalFlags()

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -183,13 +183,15 @@ void sc_SetDenormalFlags()
 
 #elif defined(__VFP_FP__)
 // vfp is the IEE-754-compliant fp unit on
-// the Cortex A8, along with the SIMD Neon unit
-// these function turns on "fast mode" by enabling
+// the Cortex A8, along with the SIMD Neon unit.
+// This function turns on "fast mode" by enabling
 // flushing denormals to zero on the VFP.
+// The NEON already flushe to zero, so it requires
+// no specific settings.
 void sc_SetDenormalFlags(){
 /* This code is from math-neon/math_runfast.c
 Copyright (c) 2015 Lachlan Tychsen-Smith (lachlan.ts@gmail.com)
-MIT License (MIT)
+MIT License
  */
 	static const unsigned int x = 0x04086060;
 	static const unsigned int y = 0x03000000;


### PR DESCRIPTION
... which includes Bela!

When compiling code on Bela, it is up to the compiler whether to generate Neon or VFP code for floating-point operations. On the Cortex A8, the Neon unit is much faster than the VFP and can also do SIMD instruction. As such, it should be preferred in most cases, but compilers seem to be pretty lazy at generating Neon code, possibly because it is not fully IEEE-754 compliant in that it always flushes denormals to zero.

All of this said, in this PR we tell the VFP to flush denormals to zero, making it run a bit faster, so that we reduce the performance penalty in case the compiler decides to generate VFP code.
