### PR TITLE
Defaulting to pru 1, for compatibility with the new Bela default

### DIFF
--- a/README_BELA.md
+++ b/README_BELA.md
@@ -80,26 +80,30 @@ Before we compile, here are two optional steps to make your workflow faster
     echo "cache_dir = '/extrabela/ccache'" >> ~/.ccache/ccache.conf
 
 2. alternatively, use `distcc` to make all your builds faster by off-loading the actual compilation to your host computer. You need to:
-* install a cross-compiler for gcc-4.8 on your host (e.g.: [this](http://www.welzels.de/blog/en/arm-cross-compiling-with-mac-os-x/) for Mac or a `g++-4.8-arm-linux-gnueabihf` package for your Linux distro)
-* install `distcc` on your host
-* on the host, launch `distccd` with something like `distccd --verbose --no-detach --daemon --allow 192.168.7.2 --log-level error --log-file ~/distccd.log`
+* install a cross-compiler for gcc-4.8 on your host (e.g.: [this](http://bela.io/downloads/gcc-linaro-arm-linux-gnueabihf-2014.04_mac.pkg) for Mac or a `g++-4.8-arm-linux-gnueabihf` package for your Linux distro)
+* install `distcc` on your host and make sure your cross-compiler is in the `PATH` (e.g.: on the host `export PATH=$PATH:/usr/local/linaro/arm-linux-gnueabihf/bin/`)
+* on the host, launch `distccd` with something like `distccd --verbose --no-detach --daemon --allow 192.168.7.2 --log-level error --log-file ~/distccd.log` (and then `tail ~/distccd.log` for errors)
 * then on the board run the following before the `cmake` commands below:
 
 	export DISTCC_HOSTS="192.168.7.1"
-	export CC="/usr/bin/distcc arm-linux-gnueabihf-gcc"
-	export CXX="/usr/bin/distcc arm-linux-gnueabihf-g++"
+	export CC="/usr/bin/distcc arm-linux-gnueabihf-gcc-4.8"
+	export CXX="/usr/bin/distcc arm-linux-gnueabihf-g++-4.8"
 
 NOTE: make sure you don't pass `-march=native` to the compiler when using `distcc`, or it will compile natively. So make sure you do not pass `-DNATIVE=ON` to `cmake`
 
 Then here's how to build:
 
+    # note that we explicitly choose the compiler version 4.8 here too, whichever command we use
+
     mkdir /extrabela/build
     cd /extrabela/build
-    # note that we explicitly choose the compiler version 4.8 here too, whichever command we use
+
     # here's the command WITHOUT ccache
     cmake /extrabela/supercollider -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DNOVA_SIMD=ON -DSSE=OFF -DSSE2=OFF -DINSTALL_HELP=OFF -DSC_QT=OFF -DSC_IDE=OFF -DSC_EL=OFF -DSC_ED=OFF -DSC_VIM=OFF -DSUPERNOVA=OFF -DNO_AVAHI=ON -DNATIVE=ON -DENABLE_TESTSUITE=OFF -DAUDIOAPI=bela
+
     # or here's the command WITH ccache
     cmake /extrabela/supercollider -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc-4.8 -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++-4.8 -DNOVA_SIMD=ON -DSSE=OFF -DSSE2=OFF -DINSTALL_HELP=OFF -DSC_QT=OFF -DSC_IDE=OFF -DSC_EL=OFF -DSC_ED=OFF -DSC_VIM=OFF -DSUPERNOVA=OFF -DNO_AVAHI=ON -DNATIVE=ON -DENABLE_TESTSUITE=OFF -DAUDIOAPI=bela
+
 	# or here's the command WITH distcc (it will infer the compilers from the `export CC CXX` above
     cmake /extrabela/supercollider -DNOVA_SIMD=ON -DSSE=OFF -DSSE2=OFF -DINSTALL_HELP=OFF -DSC_QT=OFF -DSC_IDE=OFF -DSC_EL=OFF -DSC_ED=OFF -DSC_VIM=OFF -DSUPERNOVA=OFF -DNO_AVAHI=ON -DENABLE_TESTSUITE=OFF -DAUDIOAPI=bela
     make

--- a/cmake_modules/FindBela.cmake
+++ b/cmake_modules/FindBela.cmake
@@ -50,7 +50,7 @@ else (BELA_INCLUDE_DIRS)
       /root/Bela/core
   )
 
-  file(GLOB BELA_SOURCE_FILES ${BELA_SOURCES_DIR}/*.cpp)
+  file(GLOB BELA_SOURCE_FILES ${BELA_SOURCES_DIR}/*.c ${BELA_SOURCES_DIR}/*.cpp)
 
   if (BELA_INCLUDE_DIR)
     set(BELA_FOUND TRUE)

--- a/server/scsynth/SC_Bela.cpp
+++ b/server/scsynth/SC_Bela.cpp
@@ -83,7 +83,7 @@ public:
 	void setAudioFramesPerAnalogFrame( int afpaf );
 	
 	void BelaAudioCallback(BelaContext *belaContext);
-	static void staticMAudioSyncSignal();
+	static void staticMAudioSyncSignal(void*);
 	static AuxiliaryTask mAudioSyncSignalTask;
 	static int countInstances;
 	static SC_SyncCondition* staticMAudioSync;
@@ -307,7 +307,7 @@ void SC_BelaDriver::BelaAudioCallback(BelaContext *belaContext)
 	Bela_scheduleAuxiliaryTask(mAudioSyncSignalTask);
 }
 
-void SC_BelaDriver::staticMAudioSyncSignal(){
+void SC_BelaDriver::staticMAudioSyncSignal(void*){
 	// ... but mode switches are still happening here, in a lower priority thread.
 	// FIXME: this triggers a mode switch in Xenomai.
 	staticMAudioSync->Signal();

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -172,7 +172,7 @@ int main(int argc, char* argv[])
         options.mBelaADCLevel = 0;
         options.mBelaDACLevel = 0;
         options.mBelaNumMuxChannels = 0;
-        options.mBelaPRU = 0;
+        options.mBelaPRU = 1;
 #endif
 
 	for (int i=1; i<argc;) {


### PR DESCRIPTION
Defaulting to PRU1 is required on the new Bela image because that is the default PRU for other Bela programs and is the one that allows to run the multiplexer capelet
.
SC does not clean after itself on the PRU unless it is closed with `/quit`(there is no signal handler, see #11), and this causes conflicts with programs running on the other PRU when you kill it.
