### PR TITLE
Check error code passed to tick() and return if it is not 'success'. …

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -398,7 +398,11 @@ extern void ElapsedTimeToChrono(double elapsed, std::chrono::system_clock::time_
 
 void SC_TerminalClient::tick( const boost::system::error_code& error )
 {
-	mTimer.cancel();
+	if (error == boost::system::errc::success) {
+		mTimer.cancel();
+	} else {
+		return;
+	}
 
 	double secs;
 	lock();


### PR DESCRIPTION
…This seems to be the solution for sensestage/supercollider/#34 and supercollider/supercollider/#2144 , however I have no explanation as to why this issue only manifests itself when QT is disabled. However, it works fine for our purposes.