### PR TITLE
Force printed lines to appear when using Xenomai rt_printf()

### DIFF
--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -387,6 +387,9 @@ void SC_AudioDriver::RunThread()
 	while (mRunThreadFlag) {
 		// wait for sync
 		mAudioSync.WaitNext();
+#ifdef BELA
+		rt_print_flush_buffers();
+#endif /* BELA */
 
 		reinterpret_cast<SC_Lock*>(mWorld->mNRTLock)->lock();
 


### PR DESCRIPTION
Flushing rt_printf buffers from a separate thread, to make sure tha the scprintf(i.e.:rt_printf) text is promptly displayed even when the output of the program is buffered (e.g.: when running from within sclang). Closes sensestage/supercollider#46