### PR TITLE
sclang: AnalogOut and DigitalOut return 0.0

### DIFF
--- a/SCClassLibrary/Common/Audio/bela/BELAUGens.sc
+++ b/SCClassLibrary/Common/Audio/bela/BELAUGens.sc
@@ -39,10 +39,12 @@ AnalogIn : UGen {
  */
 AnalogOut : UGen {
     *ar { arg analogPin = 0, output=0, mul=1.0, add=0.0;
-        ^this.multiNew('audio', analogPin, output ).madd(mul,add)
+        this.multiNew('audio', analogPin, output ).madd(mul,add);
+        ^0.0;
     }
     *kr { arg analogPin = 0, output=0, mul=1.0, add=0.0;
-        ^this.multiNew('control', analogPin, output ).madd(mul,add)
+        this.multiNew('control', analogPin, output ).madd(mul,add);
+        ^0.0;
     }
 	numOutputs { ^0 }
 	writeOutputSpecs {}
@@ -68,10 +70,12 @@ DigitalIn : UGen {
  */
 DigitalOut : UGen {
     *ar { arg digitalPin = 0, output=0, writeMode=0, mul=1.0, add=0.0;
-        ^this.multiNew('audio', digitalPin, output, writeMode ).madd(mul,add)
+        this.multiNew('audio', digitalPin, output, writeMode ).madd(mul,add);
+        ^0.0;
     }
     *kr { arg digitalPin = 0, output=0, writeMode=0, mul=1.0, add=0.0;
-        ^this.multiNew('control', digitalPin, output, writeMode ).madd(mul,add)
+        this.multiNew('control', digitalPin, output, writeMode ).madd(mul,add);
+        ^0.0;
     }
     numOutputs { ^0 }
     writeOutputSpecs {}


### PR DESCRIPTION

<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------
Fixes #61.
For UGens without any output, such as AnalogOut and DigitalOut, returning 0.0 prevents the creation of a wrapping Out UGen, which in turn was seen messing with poll rates in issue #61.
This technique was copied from other outputless UGens, such as SendTrig.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
