### PR TITLE
BelaScope: busless implementation

### DIFF
--- a/HelpSource/Classes/BelaScope.schelp
+++ b/HelpSource/Classes/BelaScope.schelp
@@ -16,9 +16,19 @@ list::
 ## an instance of Server running on a Bela (either locally or remotely). 
 
 ## ServerOptions.belaMaxScopeChannels should be set > 0 for Bela's server. 
-It represents the maximum number of channels that is possible to scope on that server, and causes bus and resources allocation. 
+It represents the maximum number of channels that is possible to scope on that server, and affects resources allocation. 
 If set <= 0, the server won't instantiate any Scope object, and any attempt to instantiate a BelaScope from sclang will throw an error.
 ::
+
+note:: 
+When controlling a remote Bela server, it is necessary to manually set its code::belaMaxScopeChannels:: to the corresponding value set on the Bela when the server was booted:
+code::
+// Example:
+~belaServer = Server.remote(\bela, NetAddr("192.168.6.2", 57110), ServerOptions().belaMaxScopeChannels_(4));
+::
+::
+
+If, when a client attempts to create a new BelaScope, there is one already initialized on the server, the client will notice and try to connect to the already initialized one.
 
 subsection:: Usage
 Once a Bela server is started with options.belaMaxScopeChannels > 0, it is possible to scope UGens and Busses using their .belaScope() methods. See examples below.
@@ -96,7 +106,6 @@ Examples::
 code::
 ~belaServer = Server.remote(\bela, NetAddr("192.168.6.2", 57110));
 ~belaServer.options.maxBelaScopeChannels = 8;
-~belaServer.reboot;
 
 // UGens: usage like .poll
 // scope the LFNoise0, and still use it to modulate a SinOsc

--- a/HelpSource/Classes/BelaScopeOut.schelp
+++ b/HelpSource/Classes/BelaScopeOut.schelp
@@ -1,0 +1,18 @@
+class:: BelaScopeOut
+summary:: Bela's Oscilloscope interface
+categories::  UGens>BELA
+
+Description::
+note::
+This UGen only works on Bela
+::
+This UGen effectively sends audio signals to Bela Oscilloscope, analogously to how link::/Classes/Out:: writes to a bus. 
+It can be used directly, or through link::Classes/UGen#-belaScope::, link::Classes/Array#-belaScope::, link::Classes/Bus#-belaScope::, link::Classes/Function#-belaScope:: and link::Classes/Server#-belaScope:: convenience functions.
+
+classmethods::
+
+method::ar
+argument::offset
+The Bela Oscilloscope's channel where to start writing.
+argument::channelsArray
+An array of UGens to be scoped.

--- a/HelpSource/Classes/BelaScopeUGen.schelp
+++ b/HelpSource/Classes/BelaScopeUGen.schelp
@@ -1,5 +1,5 @@
 class:: BelaScopeUGen
-summary:: Bela's Oscilloscope interface
+summary:: Bela's Oscilloscope background worker
 categories::  UGens>BELA
 
 Description::
@@ -8,10 +8,10 @@ This UGen only works on Bela
 ::
 This UGen is used internally to plot signals to Bela's Oscilloscope. Direct usage of this UGen should never be needed. See link::Classes/BelaScope::
 
+BelaScopeUGen allocates the internal buffer where link::Classes/BelaScopeOut:: UGens can write data to be scoped. Only one instance of BelaScopeUGen is allowed to be operational at the same time,
+ exceeding instances will be inactive, and won't become active even if they later become the only instance present.
+If, at creation time, a BelaScopeUGen detects other already present instances, it will set its Done flag and consequently free its enclosing synth.
 classmethods::
 
 method::ar
-argument::busnum
-index of the bus from which to read data to be scoped
-argument::numChannels
-number of channels to read and 
+This method takes no arguments. Once a BelaScopeUGen is active on the server, it will log data from all channels of its internal buffer to Bela's Scope once for every audio processing block.

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -769,4 +769,4 @@ This server's bus index to scope. Defaults to 0.
 argument:: numChannels
 Number of channels to send to BelaScope, starting from the index supplied. Defaults to 2, or to link::Classes/ServerOptions#-numOutputBusChannels:: if index is 0.
 
-returns:: A link::Classes/Monitor::, linking this Server's desired bus channels to BelaScope's bus.
+returns:: A link::Classes/Synth::, linking this Server's desired bus channels to BelaScope's bus.

--- a/SCClassLibrary/Common/Audio/bela/BELAUGens.sc
+++ b/SCClassLibrary/Common/Audio/bela/BELAUGens.sc
@@ -97,14 +97,24 @@ DigitalIO : UGen {
     }
 }
 
-/* input 1: bus
- * input 2: number of channels to scope
- */
-BelaScopeUGen : AbstractOut {
-    *ar { arg busnum, numChannels;
-       super.performList('new1', 'audio', In.ar(busnum, numChannels));
-       ^0.0;    // BelaScopeUGen has no outputs
+
+BelaScopeUGen : UGen {
+    *ar {
+       FreeSelfWhenDone.kr(super.new1('audio'));
+       ^0.0
     }
-    *numFixedArgs { ^0 }
-    writesToBus { ^false }
+}
+
+/* input 1: channel offset
+ * input 2: array of signals to scope
+ */
+BelaScopeOut : AbstractOut {
+    *ar {
+		arg offset = 0, channelsArray;
+		channelsArray = this.replaceZeroesWithSilence(channelsArray.asUGenInput(this).asArray);
+		this.multiNewList(['audio', offset] ++ channelsArray)
+		^0.0
+    }
+	*numFixedArgs { ^1 }
+	writesToBus { ^false }
 }


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------
While trying to fix problems with remote servers and Oscilloscope, the implementation was becoming too complex IMO. I rethought it and removed Bus reservation from the mechanism.
I kept the interface the same, but changed the implementation.
Now BelaScopeUGen allocates a region of memory (called `frameData`), where another UGen can write. BelaScopeOut writes data to that region, and BelaScopeUGen is responsible for logging it to Scope, and clearing it, once per block.

This fixes problems with multiple or restarting clients, which ranged from unnecessary multiple BelaScopeUGen instances to Bus reservation mismatches.

As an addition, BelaScopeOut can survive when BelaScopeUGen stops working. When a new BelaScopeUGen will be active, it will continue to visualize data coming from survived BelaScopeOuts.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Documentation (non-code change which corrects or adds documentation for existing features)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [ ] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->