### PR TITLE
BelaServerOptions subclass + examples and primitive fixes

### DIFF
--- a/SCClassLibrary/Common/Control/BelaServerOptions.sc
+++ b/SCClassLibrary/Common/Control/BelaServerOptions.sc
@@ -1,55 +1,55 @@
-BelaServerOptions {
+BelaServerOptions : ServerOptions {
+
+	var <>numAnalogInChannels;
+	var <>numAnalogOutChannels;
+	var <>numDigitalChannels;
+	var <>headphoneLevel;
+	var <>pgaGainLeft;
+	var <>pgaGainRight;
+	var <>speakerMuted;
+	var <>dacLevel;
+	var <>adcLevel;
+	var <>numMultiplexChannels;
+	var <>belaPRU;
+	var <>belaMaxScopeChannels;
 
 	classvar defaultValues;
 
-	*initDefaults {
-		defaultValues = IdentityDictionary.newFrom(
-			(
-				numAnalogInChannels: 2,
-				numAnalogOutChannels: 2,
-				numDigitalChannels: 16,
-				headphoneLevel: -6,
-				pgaGainLeft: 10,
-				pgaGainRight: 10,
-				speakerMuted: 0,
-				dacLevel: 0,
-				adcLevel: 0,
-				numMultiplexChannels: 0,
-				belaPRU: 1,
-				belaMaxScopeChannels: 0
-			)
-		);
-		^defaultValues;
+	*initClass {
+		defaultValues = super.defaultValues.copy.putAll((
+			numAnalogInChannels: 2,
+			numAnalogOutChannels: 2,
+			numDigitalChannels: 16,
+			headphoneLevel: -6,
+			pgaGainLeft: 10,
+			pgaGainRight: 10,
+			speakerMuted: 0,
+			dacLevel: 0,
+			adcLevel: 0,
+			numMultiplexChannels: 0,
+			belaPRU: 1,
+			belaMaxScopeChannels: 0
+		));
 	}
 
-	*addBelaOptions { |serverOptions|
-		var belaOpts = (defaultValues ?? { this.initDefaults }).copy;
-		belaOpts.keys.do { |optName|
-			serverOptions.addUniqueMethod(optName) { belaOpts[optName] };
-			serverOptions.addUniqueMethod(optName.asSetter) { |self, newValue|
-				belaOpts[optName] = newValue
-			};
-		}
+	init {
+		defaultValues.keysValuesDo { |key, val| this.instVarPut(key, val) };
 	}
 
-	*asOptionsString { |serverOptions|
-		var o = " -J " ++ this.getOpt(serverOptions, \numAnalogInChannels);
-		o = o ++ " -K " ++ this.getOpt(serverOptions, \numAnalogOutChannels);
-		o = o ++ " -G " ++ this.getOpt(serverOptions, \numDigitalChannels);
-		o = o ++ " -Q " ++ this.getOpt(serverOptions, \headphoneLevel);
-		o = o ++ " -X " ++ this.getOpt(serverOptions, \pgaGainLeft);
-		o = o ++ " -Y " ++ this.getOpt(serverOptions, \pgaGainRight);
-		o = o ++ " -A " ++ this.getOpt(serverOptions, \speakerMuted);
-		o = o ++ " -x " ++ this.getOpt(serverOptions, \dacLevel);
-		o = o ++ " -y " ++ this.getOpt(serverOptions, \adcLevel);
-		o = o ++ " -g " ++ this.getOpt(serverOptions, \numMultiplexChannels);
-		o = o ++ " -T " ++ this.getOpt(serverOptions, \belaPRU);
-		o = o ++ " -E " ++ this.getOpt(serverOptions, \belaMaxScopeChannels);
-		^o;
+	asOptionsString { | port = 57110 |
+		var o = super.asOptionsString(port);
+		o = o ++ " -J " ++ numAnalogInChannels;
+		o = o ++ " -K " ++ numAnalogOutChannels;
+		o = o ++ " -G " ++ numDigitalChannels;
+		o = o ++ " -Q " ++ headphoneLevel;
+		o = o ++ " -X " ++ pgaGainLeft;
+		o = o ++ " -Y " ++ pgaGainRight;
+		o = o ++ " -A " ++ speakerMuted;
+		o = o ++ " -x " ++ dacLevel;
+		o = o ++ " -y " ++ adcLevel;
+		o = o ++ " -g " ++ numMultiplexChannels;
+		o = o ++ " -T " ++ belaPRU;
+		o = o ++ " -E " ++ belaMaxScopeChannels;
+		^o
 	}
-
-	*getOpt { |serverOptions, optionName|
-		^(serverOptions.perform(optionName) ? defaultValues[optionName]);
-	}
-
 }

--- a/examples/bela/bela_example_analogin.scd
+++ b/examples/bela/bela_example_analogin.scd
@@ -1,5 +1,3 @@
-s = Server.default;
-
 s.options.numAnalogInChannels = 8;
 s.options.numAnalogOutChannels = 8;
 s.options.numDigitalChannels = 16;
@@ -8,16 +6,14 @@ s.options.blockSize = 16;
 s.options.numInputBusChannels = 2;
 s.options.numOutputBusChannels = 2;
 
-s.waitForBoot({
-  // modulate frequency of a sine oscillator
-  (
-  SynthDef("help-AnalogIn",{ arg out=0;
-    Out.ar(out,
-      SinOsc.ar( AnalogIn.ar( DC.ar( 0 ) ).exprange( 200, 5000 ), 0, 0.1 )
-      )
-  }).send(s);
-  );
+s.waitForBoot{
+	// modulate frequency of a sine oscillator
+	SynthDef("help-AnalogIn", {arg out=0;
+		Out.ar(out,
+			SinOsc.ar( AnalogIn.ar( DC.ar( 0 ) ).exprange( 200, 5000 ), 0, 0.1 )
+		)
+	}).send(s);
 
-  s.sync;
-  Synth.new("help-AnalogIn", target: s);
-});
+	s.sync;
+	Synth("help-AnalogIn");
+};

--- a/examples/bela/bela_example_analogin_2.scd
+++ b/examples/bela/bela_example_analogin_2.scd
@@ -1,20 +1,16 @@
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
+Server.default = Server.remote("belaServer", NetAddr("192.168.7.2", 57110));
 
 fork{
 	s.sync;
 
-	(
-	  SynthDef("help-AnalogIn",{ arg out=0;
-	    Out.ar(out,
-	      SinOsc.ar( AnalogIn.ar( DC.ar( 0 ) ).exprange( 200, 5000 ), 0, 0.1 )
-	    )
+	SynthDef("help-AnalogIn", { arg out=0;
+		Out.ar(out,
+			SinOsc.ar(AnalogIn.ar(DC.ar(0)).exprange(200, 5000), 0, 0.1)
+		)
 	}).send(s);
-	);
 
 	s.sync;
-	Synth.new("help-AnalogIn", target: s).postln;
+	Synth("help-AnalogIn").postln;
 };
 
 s.freeAll;

--- a/examples/bela/bela_example_analogout.scd
+++ b/examples/bela/bela_example_analogout.scd
@@ -1,16 +1,12 @@
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
+Server.default = Server.remote("belaServer", NetAddr("192.168.7.2", 57110));
 
 fork{
 	s.sync;
 
-	(
-	SynthDef("help-AnalogOut",{ arg out=0;
-	    AnalogOut.ar( DC.ar( 0 ), SinOsc.ar( 10, 0, 0.5, 0.5 ) );
+	SynthDef("help-AnalogOut", { arg out=0;
+		AnalogOut.ar(DC.ar(0), SinOsc.ar(10, 0, 0.5, 0.5 ));
 	}).send(s);
-	);
 
 	s.sync;
-	Synth.new("help-AnalogOut", target: s).postln;
+	Synth("help-AnalogOut").postln;
 };

--- a/examples/bela/bela_example_digital.scd
+++ b/examples/bela/bela_example_digital.scd
@@ -1,18 +1,14 @@
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
+Server.default = Server.remote("belaServer", NetAddr("192.168.7.2", 57110));
 
 fork{
 	s.sync;
 
-	(
-	SynthDef("help-DigitalIn",{ arg out=0;
+	SynthDef("help-DigitalIn", { arg out=0;
 		Out.ar(out,
-		  SinOsc.ar( 500, 0, 0.1 * DigitalIn.ar( 0 ) )
+			SinOsc.ar(500, 0, 0.1 * DigitalIn.ar(0))
 		)
 	}).send(s);
-	);
 
 	s.sync;
-	Synth.new("help-DigitalIn", target: s).postln;
+	Synth("help-DigitalIn").postln;
 };

--- a/examples/bela/bela_example_digitalio.scd
+++ b/examples/bela/bela_example_digitalio.scd
@@ -1,16 +1,12 @@
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
+Server.default = Server.remote("belaServer", NetAddr("192.168.7.2", 57110));
 
 fork{
 	s.sync;
 
-	(
 	SynthDef("help-DigitalIO",{ arg out=0;
 	    DigitalIO.ar( DC.ar( 0 ), SinOsc.ar( 10 ), K2A.ar( LFPulse.kr( 0.1 ) ) ).poll;
 	}).send(s);
-	);
 
 	s.sync;
-	Synth.new("help-DigitalIO", target: s).postln;
+	Synth("help-DigitalIO").postln;
 };

--- a/examples/bela/bela_example_digitalout.scd
+++ b/examples/bela/bela_example_digitalout.scd
@@ -1,16 +1,12 @@
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
+Server.default = Server.remote("belaServer", NetAddr("192.168.7.2", 57110));
 
 fork{
 	s.sync;
 
-	(
-	SynthDef("help-DigitalOut",{ arg out=0;
-		DigitalOut.ar( 0, SinOsc.ar( 10 ) );
+	SynthDef("help-DigitalOut", { arg out=0;
+		DigitalOut.ar(0, SinOsc.ar(10));
 	}).send(s);
-	);
 
 	s.sync;
-	Synth.new("help-DigitalOut", target: s).postln;
+	Synth("help-DigitalOut").postln;
 };

--- a/examples/bela/bela_start_scsynth.scd
+++ b/examples/bela/bela_start_scsynth.scd
@@ -1,5 +1,3 @@
-s = Server.default;
-
 s.options.numAnalogInChannels = 8;
 s.options.numAnalogOutChannels = 8;
 s.options.numDigitalChannels = 16;
@@ -15,5 +13,9 @@ s.options.numMultiplexChannels = 0;
 s.options.blockSize = 16;
 s.options.numInputBusChannels = 2;
 s.options.numOutputBusChannels = 2;
+
+// These lines enable access from remote hosts
+s.options.bindAddress = "0.0.0.0"
+s.options.maxLogins = 2
 
 s.boot;

--- a/examples/bela/bela_test_cases.scd
+++ b/examples/bela/bela_test_cases.scd
@@ -1,350 +1,311 @@
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
-
+Server.default = Server.remote("belaServer", NetAddr("192.168.7.2", 57110));
 
 /// AnalogIn
 
 // ak
 (
-SynthDef("AnalogIn",{ arg out=0;
+SynthDef("AnalogIn", { arg out=0;
 	Out.ar(out,
-		SinOsc.ar( AnalogIn.ar( 0 ).poll.exprange( 200, 5000 ), 0, 0.1 )
+		SinOsc.ar(AnalogIn.ar(0).poll.exprange(200, 5000), 0, 0.1)
 	)
 }).send(s);
 );
 
-a = Synth.new("AnalogIn", target: s).postln;
+a = Synth("AnalogIn").postln;
 a.free;
 
 // ak
 (
-SynthDef("AnalogIn",{ arg out=0;
+SynthDef("AnalogIn", { arg out=0;
 	Out.ar(out,
-		SinOsc.ar( AnalogIn.ar(
-			Stepper.kr(Impulse.kr(1), 0, 0, 7, 1 ).poll
-		).poll.exprange( 200, 5000 ), 0, 0.1 )
+		SinOsc.ar(AnalogIn.ar(
+			Stepper.kr(Impulse.kr(1), 0, 0, 7, 1).poll
+		).poll.exprange(200, 5000), 0, 0.1)
 	)
 }).send(s);
 );
 
-a = Synth.new("AnalogIn", target: s).postln;
+a = Synth("AnalogIn").postln;
 a.free;
 
 // kk
 (
-SynthDef("AnalogIn",{ arg out=0;
+SynthDef("AnalogIn", { arg out=0;
 	Out.ar(out,
-		SinOsc.ar( AnalogIn.kr(
+		SinOsc.ar(AnalogIn.kr(
 			0
-		).poll.exprange( 200, 5000 ), 0, 0.1 )
+		).poll.exprange(200, 5000), 0, 0.1)
 	)
 }).send(s);
 );
 
-a = Synth.new("AnalogIn", target: s).postln;
+a = Synth("AnalogIn").postln;
 a.free;
 
 // aa
 (
-SynthDef("AnalogIn",{ arg out=0;
+SynthDef("AnalogIn", { arg out=0;
 	Out.ar(out,
-		SinOsc.ar( AnalogIn.ar( Stepper.ar(Impulse.ar(1), 0, 0, 7, 1 ).poll ).poll.exprange( 200, 5000 ), 0, 0.1 )
+		SinOsc.ar(AnalogIn.ar(Stepper.ar(Impulse.ar(1), 0, 0, 7, 1).poll).poll.exprange(200, 5000), 0, 0.1)
 	)
 }).send(s);
 );
 
-a = Synth.new("AnalogIn", target: s).postln;
+a = Synth("AnalogIn").postln;
 a.free;
 
 
 /// AnalogOut
 
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
-
-
 // aaa
 (
-SynthDef("AnalogOut",{ arg out=0;
-	AnalogOut.ar( DC.ar( 0 ), SinOsc.ar( 10, 0, 0.5, 0.5 ) );
+SynthDef("AnalogOut", { arg out=0;
+	AnalogOut.ar(DC.ar(0), SinOsc.ar(10, 0, 0.5, 0.5));
 }).send(s);
 );
 
-a = Synth.new("AnalogOut", target: s).postln;
+a = Synth("AnalogOut").postln;
 a.free
 
 // aka
 (
-SynthDef("AnalogOut",{ arg out=0;
-	AnalogOut.ar( 0, SinOsc.ar( 10, 0, 0.5, 0.5 ) );
+SynthDef("AnalogOut", { arg out=0;
+	AnalogOut.ar(0, SinOsc.ar(10, 0, 0.5, 0.5));
 }).send(s);
 );
 
-a = Synth.new("AnalogOut", target: s).postln;
+a = Synth("AnalogOut").postln;
 a.free;
 
 // aak
 (
-SynthDef("AnalogOut",{ arg out=0;
-	AnalogOut.ar( DC.ar( 0 ), SinOsc.kr( 10, 0, 0.5, 0.5 ) );
+SynthDef("AnalogOut", { arg out=0;
+	AnalogOut.ar(DC.ar(0), SinOsc.kr(10, 0, 0.5, 0.5));
 }).send(s);
 );
 
-a = Synth.new("AnalogOut", target: s).postln;
+a = Synth("AnalogOut").postln;
 a.free
 
 // kk
-( // diverted to kk - AnalogOut becomes .kr effectively
-SynthDef("AnalogOut",{ arg out=0;
-	AnalogOut.ar( 0, SinOsc.kr( 10, 0, 0.5, 0.5 ) );
+(// diverted to kk - AnalogOut becomes .kr effectively
+SynthDef("AnalogOut", { arg out=0;
+	AnalogOut.ar(0, SinOsc.kr(10, 0, 0.5, 0.5));
 }).send(s);
 );
 
-a = Synth.new("AnalogOut", target: s).postln;
+a = Synth("AnalogOut").postln;
 a.free;
-
 
 // kk
 (
-SynthDef("AnalogOut",{ arg out=0;
-	AnalogOut.kr( 0, SinOsc.kr( 10, 0, 0.5, 0.5 ) );
+SynthDef("AnalogOut", { arg out=0;
+	AnalogOut.kr(0, SinOsc.kr(10, 0, 0.5, 0.5));
 }).send(s);
 );
 
-a = Synth.new("AnalogOut", target: s).postln;
+a = Synth("AnalogOut").postln;
 a.free;
 
 // kk + warning
 (
-SynthDef("AnalogOut",{ arg out=0;
-	AnalogOut.kr( 0, SinOsc.ar( 10, 0, 0.5, 0.5 ) );
+SynthDef("AnalogOut", { arg out=0;
+	AnalogOut.kr(0, SinOsc.ar(10, 0, 0.5, 0.5));
 }).send(s);
 );
 
-a = Synth.new("AnalogOut", target: s).postln;
+a = Synth("AnalogOut").postln;
 a.free;
-
 
 
 // DigitalIn
 
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
-
-
 // a
 (
-SynthDef("DigitalIn",{ arg out=0;
+SynthDef("DigitalIn", { arg out=0;
 	Out.ar(out,
-		SinOsc.ar( 500, 0, 0.1 * DigitalIn.ar( 0 ) )
+		SinOsc.ar(500, 0, 0.1 * DigitalIn.ar(0))
 	)
 }).send(s);
 );
 
-a = Synth.new("DigitalIn", target: s).postln;
+a = Synth("DigitalIn").postln;
 a.free;
 
 // k
 (
-SynthDef("DigitalIn",{ arg out=0;
+SynthDef("DigitalIn", { arg out=0;
 	Out.ar(out,
-		SinOsc.ar( 500, 0, 0.1 * DigitalIn.kr( 0 ) )
+		SinOsc.ar(500, 0, 0.1 * DigitalIn.kr(0))
 	)
 }).send(s);
 );
 
-a = Synth.new("DigitalIn", target: s).postln;
+a = Synth("DigitalIn").postln;
 a.free;
-
 
 
 // DigitalOut
 
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
-
 // a
 (
-SynthDef("DigitalOut",{ arg out=0;
-	DigitalOut.ar( 0, SinOsc.ar( 10 ) );
+SynthDef("DigitalOut", { arg out=0;
+	DigitalOut.ar(0, SinOsc.ar(10));
 }).send(s);
 );
 
-a = Synth.new("DigitalOut", target: s).postln;
+a = Synth("DigitalOut").postln;
 a.free;
 
 // k + warning
 (
-SynthDef("DigitalOut",{ arg out=0;
-	DigitalOut.kr( 0, SinOsc.ar( 10 ) );
+SynthDef("DigitalOut", { arg out=0;
+	DigitalOut.kr(0, SinOsc.ar(10));
 }).send(s);
 );
 
-a = Synth.new("DigitalOut", target: s).postln;
+a = Synth("DigitalOut").postln;
 a.free;
-
 
 // k
 (
-SynthDef("DigitalOut",{ arg out=0;
-	DigitalOut.kr( 0, SinOsc.kr( 10 ) );
+SynthDef("DigitalOut", { arg out=0;
+	DigitalOut.kr(0, SinOsc.kr(10));
 }).send(s);
 );
 
-a = Synth.new("DigitalOut", target: s).postln;
+a = Synth("DigitalOut").postln;
 a.free;
 
 // k + warning
 (
-SynthDef("DigitalOut",{ arg out=0;
-	DigitalOut.ar( 0, SinOsc.kr( 10 ) );
+SynthDef("DigitalOut", { arg out=0;
+	DigitalOut.ar(0, SinOsc.kr(10));
 }).send(s);
 );
 
-a = Synth.new("DigitalOut", target: s).postln;
+a = Synth("DigitalOut").postln;
 a.free;
-
 
 // a-once
 (
-SynthDef("DigitalOut",{ arg out=0;
-	DigitalOut.ar( 0, SinOsc.ar( 10 ), 1 );
+SynthDef("DigitalOut", { arg out=0;
+	DigitalOut.ar(0, SinOsc.ar(10), 1);
 }).send(s);
 );
 
-a = Synth.new("DigitalOut", target: s).postln;
+a = Synth("DigitalOut").postln;
 a.free;
-
-
 
 
 // DigitalIO
 
-
-Server.default = s = Server("belaServer", NetAddr("192.168.7.2", 57110));
-s.initTree;
-s.startAliveThread;
-
-
-( // aaaa once - everything audio rate
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( DC.ar( 0 ), SinOsc.ar( 10 ), K2A.ar( LFPulse.kr( 0.1 ) ) ).poll;
+(// aaaa once - everything audio rate
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(DC.ar(0), SinOsc.ar(10), K2A.ar(LFPulse.kr(0.1))).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-( // aaak once - pinmode control rate
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( DC.ar( 0 ), SinOsc.ar( 10 ), LFPulse.kr( 0.1 ) ).poll;
+(// aaak once - pinmode control rate
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(DC.ar(0), SinOsc.ar(10), LFPulse.kr(0.1)).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-( // aaka once - output value control rate
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( DC.ar( 0 ), SinOsc.kr( 10 ), K2A.ar( LFPulse.kr( 0.1 ) ) ).poll;
+(// aaka once - output value control rate
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(DC.ar(0), SinOsc.kr(10), K2A.ar(LFPulse.kr(0.1))).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-( // aakk once - output value control rate, pinmode control rate
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( DC.ar( 0 ), SinOsc.kr( 10 ), LFPulse.kr( 0.1 ) ).poll;
+(// aakk once - output value control rate, pinmode control rate
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(DC.ar(0), SinOsc.kr(10), LFPulse.kr(0.1)).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-( // akaa once - pin changed at control rate, rest audio
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( 0, SinOsc.ar( 10 ), K2A.ar( LFPulse.kr( 0.1 ) ) ).poll;
+(// akaa once - pin changed at control rate, rest audio
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(0, SinOsc.ar(10), K2A.ar(LFPulse.kr(0.1))).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-( // akak once - pin changed at control rate, output value at audio rate, mode at control rate
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( 0, SinOsc.ar( 10 ), LFPulse.kr( 0.1 ) ).poll;
+(// akak once - pin changed at control rate, output value at audio rate, mode at control rate
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(0, SinOsc.ar(10), LFPulse.kr(0.1)).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-( // ak once - pin changed at control rate, output control rate, pinmode control
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( 0, SinOsc.kr( 10 ), LFPulse.kr( 0.1 ) ).poll;
+(// ak once - pin changed at control rate, output control rate, pinmode control
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(0, SinOsc.kr(10), LFPulse.kr(0.1)).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-( // akka once - pin changed at control rate, output control rate, pinmode control
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.ar( 0, SinOsc.kr( 10 ), K2A.ar( LFPulse.kr( 0.1 ) ) ).poll;
+(// akka once - pin changed at control rate, output control rate, pinmode control
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.ar(0, SinOsc.kr(10), K2A.ar(LFPulse.kr(0.1))).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-
-( // kk - warning
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.kr( 0, SinOsc.kr( 10 ), K2A.ar( LFPulse.kr( 0.1 ) ) ).poll;
+(// kk - warning
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.kr(0, SinOsc.kr(10), K2A.ar(LFPulse.kr(0.1))).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-( // kk - warning
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.kr( 0, SinOsc.ar( 10 ), LFPulse.kr( 0.1 ) ).poll;
+(// kk - warning
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.kr(0, SinOsc.ar(10), LFPulse.kr(0.1)).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-( // kk - warning
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.kr( Stepper.ar( Impulse.ar(1), 0, 7, 1 ), SinOsc.kr( 10 ), LFPulse.kr( 0.1 ) ).poll;
+(// kk - warning
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.kr(Stepper.ar(Impulse.ar(1), 0, 7, 1), SinOsc.kr(10), LFPulse.kr(0.1)).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
-
-( // kk
-SynthDef("DigitalIO",{ arg out=0;
-	DigitalIO.kr( 0, SinOsc.kr( 10 ), LFPulse.kr( 0.1 ) ).poll;
+(// kk
+SynthDef("DigitalIO", { arg out=0;
+	DigitalIO.kr(0, SinOsc.kr(10), LFPulse.kr(0.1)).poll;
 }).send(s);
 );
 
-a = Synth.new("DigitalIO", target: s).postln;
+a = Synth("DigitalIO").postln;
 a.free;
 
 //

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -133,7 +133,7 @@ elseif (AUDIOAPI STREQUAL portaudio)
     list(APPEND sclang_sources ${CMAKE_SOURCE_DIR}/common/SC_PaUtils.cpp)
     include_directories(${PORTAUDIO_INCLUDE_DIRS})
 elseif (AUDIOAPI STREQUAL bela)
-    add_definitions("-DSC_AUDIO_API=SC_AUDIO_API_BELA")
+    add_definitions("-DSC_AUDIO_API_BELA")
 endif()
 
 if(UNIX)

--- a/lang/LangPrimSource/PyrPlatformPrim.cpp
+++ b/lang/LangPrimSource/PyrPlatformPrim.cpp
@@ -132,7 +132,7 @@ int prPlatform_architecture(struct VMGlobals* g, int numArgsPushed) {
 
 int prPlatform_hasBelaSupport(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot* a = g->sp;
-#if (SC_AUDIO_API == SC_AUDIO_API_BELA)
+#if defined(SC_AUDIO_API_BELA)
     SetBool(a, true);
 #else
     SetBool(a, false);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
While following the discussion at https://github.com/supercollider/supercollider/pull/5295
- Implement BelaServerOptions as a ServerOptions subclass
- BelaServerOptions is chosen automatically if Platform.hasBelaSupport
- Fix a definition that caused `Platform.hasBelaSupport` to always return `true`
- Fixed spacing and some other style details in examples

(Tested on both Bela and a Linux host, it works :) )
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
