### PR TITLE
Bela PR: smaller review patches

### DIFF
--- a/common/SC_Lock.h
+++ b/common/SC_Lock.h
@@ -27,18 +27,16 @@
 
 #ifdef __COBALT__
 #    include <XenomaiLock.h>
-typedef XenomaiMutex SC_Lock;
+using SC_Lock = XenomaiMutex;
+using condition_variable_any = XenomaiConditionVariable;
 #else // __COBALT__
-typedef std::mutex SC_Lock;
+using SC_Lock = std::mutex;
+using condition_variable_any = std::condition_variable_any;
 #endif // __COBALT__
-typedef std::thread SC_Thread;
+
+using SC_Thread = std::thread;
 using std::cv_status;
 using std::lock_guard;
 using std::timed_mutex;
 using std::unique_lock;
-#ifdef __COBALT__
-typedef XenomaiConditionVariable condition_variable_any;
-#else // __COBALT__
-typedef std::condition_variable_any condition_variable_any;
-#endif // __COBALT__
-typedef SC_Lock mutex;
+using mutex = SC_Lock;

--- a/common/SC_SyncCondition.h
+++ b/common/SC_SyncCondition.h
@@ -62,11 +62,11 @@ public:
         ++write;
 #ifdef SC_CONDITION_VARIABLE_ANY_SHOULD_LOCK_BEFORE_NOTIFY
         if (mutex.try_lock()) {
-#endif // CONDITION_VARIABLE_ANY_SHOULD_LOCK_BEFORE_NOTIFY
             available.notify_one();
-#ifdef SC_CONDITION_VARIABLE_ANY_SHOULD_LOCK_BEFORE_NOTIFY
             mutex.unlock();
         }
+#else // CONDITION_VARIABLE_ANY_SHOULD_LOCK_BEFORE_NOTIFY
+        available.notify_one();
 #endif // CONDITION_VARIABLE_ANY_SHOULD_LOCK_BEFORE_NOTIFY
     }
 

--- a/lang/LangPrimSource/PyrPlatformPrim.cpp
+++ b/lang/LangPrimSource/PyrPlatformPrim.cpp
@@ -132,7 +132,7 @@ int prPlatform_architecture(struct VMGlobals* g, int numArgsPushed) {
 
 int prPlatform_hasBelaSupport(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot* a = g->sp;
-#if defined(SC_AUDIO_API_BELA)
+#ifdef SC_AUDIO_API_BELA
     SetBool(a, true);
 #else
     SetBool(a, false);

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -37,9 +37,10 @@
 #    include <unistd.h> // for _POSIX_MEMLOCK
 #    include <sys/wait.h>
 #endif
+
 #ifdef __COBALT__
 #    include "XenomaiLock.h"
-XenomaiInitializer xenomaiInitializer;
+static XenomaiInitializer xenomaiInitializer;
 #endif // __COBALT__
 
 #ifdef _WIN32


### PR DESCRIPTION
this is one part of the C++ changes i'd like to see to the bela branch:

- switch over typedef to using
- simplify some preprocessor code
- avoid raw malloc when not needed (it's my understanding from documentation that xenomai_init makes a copy of the input for itself)
- simplify conditionals in XenomaiLock constructor

if you agree with these, please merge, thanks!