### PR TITLE
Bela: XenomaiLock review patches

### DIFF
--- a/common/XenomaiLock.cpp
+++ b/common/XenomaiLock.cpp
@@ -115,14 +115,16 @@ template <typename F, typename T> static bool tryOrRetryImpl(F&& func, bool enab
 
     int ret = func();
     // 0 is "success" (or at least meaningful failure)
-    if (ret == 0) {
+    if (0 == ret) {
         return true;
-    } else if (ret != EPERM) {
+    } else if (EPERM != ret) {
         return false;
-    } else if (!turnIntoCobaltThread()) {
+    } else {
         // if we got EPERM, we are not a Xenomai thread
-        xfprintf(stderr, "%s %p could not turn into cobalt\n", name, id);
-        return false;
+        if (!turnIntoCobaltThread()) {
+            xfprintf(stderr, "%s %p could not turn into cobalt\n", name, id);
+            return false;
+        }
     }
 
     // retry after becoming a cobalt thread

--- a/common/XenomaiLock.cpp
+++ b/common/XenomaiLock.cpp
@@ -49,7 +49,7 @@ static void initialize_xenomai() {
     xenomai_init(&argc, argvPtrs);
 }
 
-static int turn_into_cobalt_thread(bool recurred = false) {
+static bool turn_into_cobalt_thread(bool recurred = false) {
     int current_mode = cobalt_thread_mode();
     struct sched_param param;
     memset(&param, 0, sizeof(param));
@@ -64,10 +64,10 @@ static int turn_into_cobalt_thread(bool recurred = false) {
         if (!recurred)
             return turn_into_cobalt_thread(true);
         else
-            return -1;
+            return false;
     }
     xprintf("Turned thread %d into a Cobalt thread %s\n", tid, recurred ? "with recursion" : "");
-    return 0;
+    return true;
 }
 
 XenomaiInitializer::XenomaiInitializer() { initialize_xenomai(); }
@@ -117,7 +117,7 @@ template <typename F, typename T> static bool try_or_retry_impl(F&& func, bool e
         return true;
     } else if (ret != EPERM) {
         return false;
-    } else if (turn_into_cobalt_thread()) {
+    } else if (!turn_into_cobalt_thread()) {
         // if we got EPERM, we are not a Xenomai thread
         xfprintf(stderr, "%s %p could not turn into cobalt\n", name, id);
         return false;

--- a/common/XenomaiLock.cpp
+++ b/common/XenomaiLock.cpp
@@ -188,7 +188,7 @@ void XenomaiConditionVariable::wait(std::unique_lock<XenomaiMutex>& lck) {
 
     // It may throw system_error in case of failure (transmitting any error condition from the respective call to lock
     // or unlock). The predicate version (2) may also throw exceptions thrown by pred.
-    tryOrRetry([this, &lck]() { return __wrap_pthread_cond_wait(&this->cond, &lck.mutex()->mutex); }, enabled);
+    tryOrRetry(([this, &lck]() { return __wrap_pthread_cond_wait(&this->cond, &lck.mutex()->mutex); }), enabled);
 }
 
 void XenomaiConditionVariable::notify_one() noexcept {

--- a/common/XenomaiLock.cpp
+++ b/common/XenomaiLock.cpp
@@ -62,7 +62,7 @@ static int turn_into_cobalt_thread(bool recurred = false) {
                 strerror(-ret));
         initialize_xenomai();
         if (!recurred)
-            return turn_into_cobalt_thread(1);
+            return turn_into_cobalt_thread(true);
         else
             return -1;
     }

--- a/common/XenomaiLock.cpp
+++ b/common/XenomaiLock.cpp
@@ -26,6 +26,7 @@
 #    define xfprintf(...)
 #endif // PRINT_XENO_LOCK
 
+// Standard Linux `gettid(2)` not available on Bela
 static inline pid_t get_tid() {
     pid_t tid = syscall(SYS_gettid);
     return tid;

--- a/common/XenomaiLock.cpp
+++ b/common/XenomaiLock.cpp
@@ -51,11 +51,12 @@ static void initializeXenomai() {
 }
 
 static bool turnIntoCobaltThread(bool recurred = false) {
-    int current_mode = cobalt_thread_mode();
     struct sched_param param;
     memset(&param, 0, sizeof(param));
     int policy;
-    int ret = pthread_getschedparam(pthread_self(), &policy, &param);
+    // Guaranteed to succeed as pthread_self() cannot fail and pthread_getschedparam()'s only error condition is when
+    // the given thread does not exist.
+    pthread_getschedparam(pthread_self(), &policy, &param);
     pid_t tid = getTid();
 
     if (int ret = __wrap_sched_setscheduler(tid, policy, &param)) {

--- a/common/XenomaiLock.h
+++ b/common/XenomaiLock.h
@@ -18,11 +18,11 @@ class XenomaiMutex {
 
 public:
     XenomaiMutex();
-    XenomaiMutex(std::unique_lock<XenomaiMutex>&);
     ~XenomaiMutex();
-    bool try_lock(bool recurred = false);
-    void lock(bool recurred = false);
-    void unlock(bool recurred = false);
+
+    bool try_lock();
+    void lock();
+    void unlock();
 
 private:
     pthread_mutex_t mutex;
@@ -33,9 +33,10 @@ class XenomaiConditionVariable {
 public:
     XenomaiConditionVariable();
     ~XenomaiConditionVariable();
-    void wait(std::unique_lock<XenomaiMutex>& lck, bool recurred = false);
-    void notify_one(bool recurred = false) noexcept;
-    void notify_all(bool recurred = false) noexcept;
+
+    void wait(std::unique_lock<XenomaiMutex>& lck);
+    void notify_one() noexcept;
+    void notify_all() noexcept;
 
 private:
     pthread_cond_t cond;


### PR DESCRIPTION
this PR revises XenomaiLock with some miscellaneous improvements:
- adhere to webkit naming conventions for functions (https://webkit.org/code-style-guidelines/#names)
- remove an undefined constructor declaration
- remove `recurred` boolean params from public interfaces
- improve type correctness (int vs bool)
- remove unused variables
- fix an incorrect printf format

i also redid the try_or_retry function to avoid std::function and have a bit cleaner interface that doesn't require passing actual names or object pointers explicitly. since the only purpose of those parameters is to debug by tracking events, using `this` instead of pointers to condition var or mutex should provide the same information, just with less code. same goes for using `__func__` instead of handwritten function names -- the result is identical, but there is less chance of a mix-up due to copy-paste mistakes.

std::function should be avoided for performance-sensitive code because it may dynamically allocate if the stored callable is not a simple function pointer or reference wrapper; it's better to take the lambda as a parameter directly in this case, as it will very likely be inlined by the compiler that way. you can see an example of this here: https://godbolt.org/z/6zKh1a